### PR TITLE
Add alias jh to use jhipster cli

### DIFF
--- a/conf.d/jhipster.aliases.fish
+++ b/conf.d/jhipster.aliases.fish
@@ -1,3 +1,4 @@
+alias jh='jhipster'
 alias jhyarn='yo jhipster --yarn'
 alias jhskip='yo jhipster --skip-install'
 alias jhinstall='npm install; and bower install; and gulp install'


### PR DESCRIPTION
Following this commit https://github.com/jhipster/generator-jhipster/commit/dad7257e4bb4750ebad6e740c820eb378bc04143, add back the `jh` alias to use directly `jhipster`